### PR TITLE
feat: guide 페이지 레이아웃

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "react-icons": "^4.6.0",
         "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
-        "styled-components": "^5.3.6",
-        "styled-reset": "^4.4.2"
+        "styled-components": "^5.3.6"
       },
       "devDependencies": {
         "eslint": "^8.25.0",
@@ -15686,21 +15685,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/styled-reset": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
-      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/zacanger"
-      },
-      "peerDependencies": {
-        "styled-components": ">=4.0.0 || >=5.0.0"
-      }
-    },
     "node_modules/stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -28680,12 +28664,6 @@
           }
         }
       }
-    },
-    "styled-reset": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
-      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
-      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/src/pages/GuidePage/index.js
+++ b/src/pages/GuidePage/index.js
@@ -1,5 +1,32 @@
 import React from "react";
+import styled from "styled-components";
+import theme from "../../config/constants/theme";
 
 export default function GuidePage() {
-  return <div>GuidePage</div>;
+  return (
+    <Container>
+      <GuideWrapper>
+        <h1>guide</h1>
+      </GuideWrapper>
+    </Container>
+  );
 }
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 32px;
+  background-color: ${theme.skyBlue};
+`;
+
+const GuideWrapper = styled.section`
+  width: 1056px;
+  min-height: 1056px;
+  padding: 96px;
+  margin: 36px;
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
+  background-color: white;
+  border: none;
+`;


### PR DESCRIPTION
## 작업 사항
- 이후에 들어갈 서비스 이용 가이드 페이지 레이아웃 제작
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/95201149/196101915-c03a0888-1f01-471a-82f0-e1510cdaa7a7.png">

## 잘 봐주세요
- 화면 구성과 크기

## PR 전 확인사항
[x] 가장 최신 브랜치를 pull했습니다.
[x] base 브랜치명을 확인했습니다.
[x] 코드 컨벤션을 모두 지켰습니다.
[x] 적절한 라벨이 있습니다.
[x] assignee가 있습니다.

## 비고
